### PR TITLE
Add optional output key

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ The main result is streamed using [JSONStream](https://github.com/dominictarr/JS
 
 ## API
 
-#### `stream = format(metadata)`
+#### `stream = format(metadata, options)`
 
 Creates a new JSON formatter. Any metadata properties you provide in the constructor will be set in the beginning of the JSON response.
+
+Pass `options.outputKey` to specify which key data is added to. Defaults to `result`.
+
+``` js
+var stream = format(null, {outputKey: 'data'})
+```
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var through = require('through2')
 var JSONStream = require('JSONStream')
 var duplexify = require('duplexify')
 
-module.exports = function (metadata) {
+module.exports = function (metadata, opts) {
+  var outputKey = (opts && opts.outputKey) || 'result'
   var err = null
 
   var inp = JSONStream.stringify()
@@ -22,7 +23,7 @@ module.exports = function (metadata) {
     })
   }
 
-  out.push('"result":')
+  out.push('"' + outputKey + '":')
 
   var dup = duplexify.obj(inp, out, {destroy: false})
 

--- a/test.js
+++ b/test.js
@@ -52,3 +52,15 @@ tape('metadata', function (t) {
     t.end()
   }))
 })
+
+tape('opts.outputKey', function (t) {
+  var stream = format(null, {outputKey: 'data'})
+
+  stream.write({hello: 'world'})
+  stream.end()
+
+  stream.pipe(concat(function (data) {
+    t.same(JSON.parse(data), {data: [{hello: 'world'}], error: null})
+    t.end()
+  }))
+})


### PR DESCRIPTION
This adds an option for overriding the key data is written to.

``` js
var format = require('json-format-stream')

var stream = format(null, {outputKey: 'data')

stream.write({some: 'data'})
stream.write({more: 'data'})
stream.destroy(new Error('an error occurred'))

stream.pipe(process.stdout)
```

Running the above will print out

```
{
  "data": [
    {
      "some": "data"
    },
    {
      "more": "data"
    }
  ],
  "error": "an error occurred"
}
```
